### PR TITLE
feat(s3): add parallel push of layers to s3

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -242,6 +242,10 @@ func (e *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 		}(i, l)
 	}
 
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
 	dt, err := json.Marshal(cacheConfig)
 	if err != nil {
 		return nil, err

--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -183,7 +183,6 @@ func (e *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 	for i, l := range cacheConfig.Layers {
 		func(i int, l v1.CacheLayer) {
 			eg.Go(func() error {
-
 				dgstPair, ok := descs[l.Blob]
 				if !ok {
 					return errors.Errorf("missing blob %s", l.Blob)


### PR DESCRIPTION
The pushing of cached layers to S3 is serial and quite slow.
It appears that we can make it parallel for a large increase in speed.

The goal is to make the S3 cache a usable backup to local disk caching.