### PR TITLE
perf: switch num concurrent layer fetch/push to 12

### DIFF
--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -20,7 +20,7 @@ type contextKeyT string
 
 var contextKey = contextKeyT("buildkit/util/resolver/limited")
 
-var Default = New(4)
+var Default = New(12)
 
 type Group struct {
 	mu   sync.Mutex


### PR DESCRIPTION
We are seeing slow container push and are wondering if the global pool of concurrent layer pushes is causing a slowdown.

This PR addresses both concurrent fetch and pulls as the same global variable controls the semaphore weight.