### PR TITLE
feat: return index, config, and manifest

### DIFF
--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -14,6 +14,11 @@ const (
 	ExporterBuildInfo            = "containerimage.buildinfo" // Deprecated: Build information is deprecated: https://github.com/moby/buildkit/blob/master/docs/deprecated.md
 	ExporterPlatformsKey         = "refs.platforms"
 	ExporterEpochKey             = "source.date.epoch"
+
+	// DEPOT: added to receive the manifest directly for the image.
+	DepotContainerImageIndex    = "depot.containerimage.index"
+	DepotContainerImageManifest = "depot.containerimage.manifest"
+	DepotContainerImageConfig   = "depot.containerimage.config"
 )
 
 // KnownRefMetadataKeys are the subset of exporter keys that can be suffixed by

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -310,6 +310,10 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	}
 	idxDone(nil)
 
+	// DEPOT: Add image index so we can use it to pull the image in the depot client.
+	// This image index contains manifests for all platforms.
+	idxDesc.Annotations[exptypes.DepotContainerImageIndex] = string(idxBytes)
+
 	return &idxDesc, nil
 }
 
@@ -444,6 +448,12 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 		return nil, nil, configDone(errors.Wrap(err, "error writing config blob"))
 	}
 	configDone(nil)
+
+	// DEPOT: Add manifest so it can be sent back to the depot client.
+	// We need this as the manifest does not appear to always
+	// be available in the content store.
+	annotations.ManifestDescriptor[exptypes.DepotContainerImageManifest] = string(mfstJSON)
+	annotations.ManifestDescriptor[exptypes.DepotContainerImageConfig] = string(config)
 
 	return &ocispecs.Descriptor{
 		Annotations: annotations.ManifestDescriptor,

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6564,7 +6564,7 @@ FROM scratch
 COPY --from=0 / /
 `)
 
-	const expectedDigest = "sha256:4b9a241cddc0b6f415b6d09264749c8abffbca6f7b3c7b0e9970599bd210237e"
+	const expectedDigest = "sha256:febcf750a388bdbe9461d6b19a8c7cc098ccd7b787bb6473cce5e87977376c8b"
 
 	dir, err := integration.Tmpdir(
 		t,


### PR DESCRIPTION
When exporting images to pull with the depot cli
the manifest and config may have been garbage collected.

This returns the index, config, and manifest as annotations
within the solve response to workaround garbage collection
as the files are not removed until after solve returns.