### PR TITLE
Background the cache metadata cleanup

### DIFF
--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -25,9 +25,12 @@ func NewCacheManager(ctx context.Context, id string, storage CacheKeyStorage, re
 		results: results,
 	}
 
-	if err := cm.ReleaseUnreferenced(); err != nil {
-		bklog.G(ctx).Errorf("failed to release unreferenced cache metadata: %+v", err)
-	}
+	// DEPOT: background the cleanup
+	go func() {
+		if err := cm.ReleaseUnreferenced(); err != nil {
+			bklog.G(ctx).Errorf("failed to release unreferenced cache metadata: %+v", err)
+		}
+	}()
 
 	return cm
 }


### PR DESCRIPTION
This moves the cache metadata cleanup process to a background goroutine - we have observed BuildKit taking up to 9 minutes to process this cleanup, and we don't want to block startup.