### PR TITLE
feat(load): add new lease tracking all image layers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	leasesapi "github.com/containerd/containerd/api/services/leases/v1"
 	"github.com/containerd/containerd/defaults"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	controlapi "github.com/moby/buildkit/api/services/control"
@@ -178,6 +179,10 @@ func (c *Client) ControlClient() controlapi.ControlClient {
 
 func (c *Client) ContentClient() contentapi.ContentClient {
 	return contentapi.NewContentClient(c.conn)
+}
+
+func (c *Client) LeasesClient() leasesapi.LeasesClient {
+	return leasesapi.NewLeasesClient(c.conn)
 }
 
 func (c *Client) Dialer() session.Dialer {

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client/connhelper"
 	"github.com/moby/buildkit/depot"
+	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/util/appdefaults"
@@ -183,6 +184,10 @@ func (c *Client) ContentClient() contentapi.ContentClient {
 
 func (c *Client) LeasesClient() leasesapi.LeasesClient {
 	return leasesapi.NewLeasesClient(c.conn)
+}
+
+func (c *Client) LLBBridgeClient() gatewayapi.LLBBridgeClient {
+	return gatewayapi.NewLLBBridgeClient(c.conn)
 }
 
 func (c *Client) Dialer() session.Dialer {

--- a/control/control.go
+++ b/control/control.go
@@ -134,6 +134,7 @@ func (c *Controller) Register(server *grpc.Server) {
 	leasesapi.RegisterLeasesServer(server, &LeaseManager{c.opt.LeaseManager})
 }
 
+// DEPOT: This lease manager is used by the CLI to remove image leases after load.
 type LeaseManager struct {
 	manager leases.Manager
 }

--- a/control/control.go
+++ b/control/control.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	leasesapi "github.com/containerd/containerd/api/services/leases/v1"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/services/content/contentserver"
 	"github.com/docker/distribution/reference"
+	"github.com/gogo/protobuf/types"
 	"github.com/mitchellh/hashstructure/v2"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	apitypes "github.com/moby/buildkit/api/types"
@@ -129,6 +131,39 @@ func (c *Controller) Register(server *grpc.Server) {
 
 	store := &roContentStore{c.opt.ContentStore}
 	contentapi.RegisterContentServer(server, contentserver.New(store))
+	leasesapi.RegisterLeasesServer(server, &LeaseManager{c.opt.LeaseManager})
+}
+
+type LeaseManager struct {
+	manager leases.Manager
+}
+
+func (m *LeaseManager) Delete(ctx context.Context, req *leasesapi.DeleteRequest) (*types.Empty, error) {
+	err := m.manager.Delete(ctx, leases.Lease{ID: req.ID})
+	if err != nil {
+		return nil, err
+	}
+	return &types.Empty{}, nil
+}
+
+func (*LeaseManager) Create(context.Context, *leasesapi.CreateRequest) (*leasesapi.CreateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet supported")
+}
+
+func (m *LeaseManager) List(ctx context.Context, req *leasesapi.ListRequest) (*leasesapi.ListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet supported")
+}
+
+func (m *LeaseManager) AddResource(context.Context, *leasesapi.AddResourceRequest) (*types.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet supported")
+}
+
+func (m *LeaseManager) DeleteResource(context.Context, *leasesapi.DeleteResourceRequest) (*types.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet supported")
+}
+
+func (m *LeaseManager) ListResources(ctx context.Context, req *leasesapi.ListResourcesRequest) (*leasesapi.ListResourcesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet supported")
 }
 
 func (c *Controller) DiskUsage(ctx context.Context, r *controlapi.DiskUsageRequest) (*controlapi.DiskUsageResponse, error) {

--- a/depot/lease.go
+++ b/depot/lease.go
@@ -1,0 +1,5 @@
+package depot
+
+// LeaseLabel identifies the lease's ID during an export of the image.
+// I happen to use the session ID as it is unique to this specific export.
+const ExportLeaseLabel = "depot/session.id"

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -422,6 +422,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 		mfst.Layers = append(mfst.Layers, desc)
 	}
 
+	// DEPOT: Attach all layers to the depot export lease so we can use them to pull the image in the depot client.
 	leaseID, ok := ctx.Value(DepotLeaseKey{}).(string)
 	if ok && leaseID != "" {
 		for _, layer := range mfst.Layers {

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -179,10 +179,11 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 	sm.Register(os)
 
 	iw, err := imageexporter.NewImageWriter(imageexporter.WriterOpt{
-		Snapshotter:  opt.Snapshotter,
-		ContentStore: opt.ContentStore,
-		Applier:      opt.Applier,
-		Differ:       opt.Differ,
+		Snapshotter:   opt.Snapshotter,
+		ContentStore:  opt.ContentStore,
+		Applier:       opt.Applier,
+		Differ:        opt.Differ,
+		LeasesManager: opt.LeaseManager,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The manifest, config, and layers of newly created images
could be garbage collected before they are pulled by the CLI.

This new lease will inhibit GC until the lease is removed or
one hour has passed.

The lease ID can be accessed by the returned annotation
`depot/session.id`.

Co-authored-by: Jacob Gillespie <jacobwgillespie@gmail.com>
Signed-off-by: Chris Goller <goller@gmail.com>