### PR TITLE
Reduce default auth credential expiration to 10 minutes

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -28,7 +28,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const defaultExpiration = 60
+// DEPOT: we have reduced this from 60 minutes to 10 minutes
+const defaultExpiration = 10
 
 func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -23,7 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const defaultExpiration = 60
+// DEPOT: we have reduced this from 60 minutes to 10 minutes
+const defaultExpiration = 10
 
 type authHandlerNS struct {
 	counter int64 // needs to be 64bit aligned for 32bit systems


### PR DESCRIPTION
We want to be able to support shorter-lived access credentials for registries that don't report token expiration. This reduces the previous default of 60 minutes to 10 minutes.