### PR TITLE
feat(export): return manifests for exported images

### DIFF
--- a/depot/manifest.go
+++ b/depot/manifest.go
@@ -1,0 +1,33 @@
+package depot
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ExportManifests is an array of base64-encoded JSON ocispec Manifests.
+const ExportManifests = "depot/export.manifests"
+
+// MarshalManifests encodes the manifests to a format that can
+// be sent using the Solve Response.  Solve Response is a map[string]string.
+func MarshalManifests(manifests []*ocispecs.Manifest) (string, error) {
+	octets, err := json.Marshal(manifests)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(octets), nil
+}
+
+// UnmarshalManifests decodes the manifests from a Solve Response.
+func UnmarshalManifests(data string) ([]ocispecs.Manifest, error) {
+	octets, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifests []ocispecs.Manifest
+	err = json.Unmarshal(octets, &manifests)
+	return manifests, err
+}

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -252,7 +252,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}()
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
+	desc, manifests, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -394,6 +394,12 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		return nil, nil, err
 	}
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
+
+	encodedManifests, err := depot.MarshalManifests(manifests)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp[depot.ExportManifests] = encodedManifests
 
 	return resp, nil, nil
 }

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -143,7 +143,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}()
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
+	desc, _, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
We would like to see the sizes of all layers for the manifest. This also cleans up some tech debt with passing data to load.

The solve response has a new key `depot/export.manifests` that is a base64 encoded array of OCI manifests.