### PR TITLE
feat: add gpu support for oci worker

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -89,6 +89,9 @@ type OCIConfig struct {
 
 	// MaxParallelism is the maximum number of parallel build steps that can be run at the same time.
 	MaxParallelism int `toml:"max-parallelism"`
+
+	// Enables GPU support using nvidia-container-toolkit.
+	GPU bool `toml:"gpu"`
 }
 
 type ContainerdConfig struct {

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -119,6 +119,10 @@ func init() {
 			Name:  "oci-worker-selinux",
 			Usage: "apply SELinux labels",
 		},
+		cli.BoolFlag{
+			Name:  "oci-worker-gpu",
+			Usage: "enable gpu support",
+		},
 	}
 	n := "oci-worker-rootless"
 	u := "enable rootless mode"
@@ -247,6 +251,9 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-worker-selinux") {
 		cfg.Workers.OCI.SELinux = c.GlobalBool("oci-worker-selinux")
 	}
+	if c.GlobalIsSet("oci-worker-gpu") {
+		cfg.Workers.OCI.GPU = c.GlobalBool("oci-worker-gpu")
+	}
 
 	return nil
 }
@@ -307,7 +314,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		parallelismSem = semaphore.NewWeighted(int64(cfg.MaxParallelism))
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, cfg.GPU, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -177,7 +177,9 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	}
 
 	processMode := oci.ProcessSandbox // FIXME(AkihiroSuda)
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, processMode, nil, w.apparmorProfile, w.selinux, w.traceSocket, opts...)
+	// DEPOT: do not support GPU for containerd for now.
+	const gpuSupport = false
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, processMode, nil, w.apparmorProfile, w.selinux, gpuSupport, w.traceSocket, opts...)
 	if err != nil {
 		return err
 	}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -49,6 +49,7 @@ type Opt struct {
 	OOMScoreAdj     *int
 	ApparmorProfile string
 	SELinux         bool
+	GPU             bool
 	TracingSocket   string
 }
 
@@ -69,6 +70,7 @@ type runcExecutor struct {
 	mu               sync.Mutex
 	apparmorProfile  string
 	selinux          bool
+	gpu              bool
 	tracingSocket    string
 }
 
@@ -134,6 +136,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		running:          make(map[string]chan error),
 		apparmorProfile:  opt.ApparmorProfile,
 		selinux:          opt.SELinux,
+		gpu:              opt.GPU,
 		tracingSocket:    opt.TracingSocket,
 	}
 	return w, nil
@@ -254,7 +257,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		}
 	}
 
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, w.processMode, w.idmap, w.apparmorProfile, w.selinux, w.tracingSocket, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, w.processMode, w.idmap, w.apparmorProfile, w.selinux, w.gpu, w.tracingSocket, opts...)
 	if err != nil {
 		return err
 	}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -35,7 +35,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, selinux, gpu bool, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -67,6 +67,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		DNS:                 dns,
 		ApparmorProfile:     apparmorProfile,
 		SELinux:             selinux,
+		GPU:                 gpu,
 		TracingSocket:       traceSocket,
 		DefaultCgroupParent: defaultCgroupParent,
 	}, np)

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -38,7 +38,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) base.WorkerOpt {
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", false, nil, "", "")
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", false, false, nil, "", "")
 	require.NoError(t, err)
 
 	return workerOpt


### PR DESCRIPTION
Requires `--oci-worker-binary /usr/bin/nvidia-container-runtime` and `--oci-worker-gpu` from the nvidia-container-toolkit.