### PR TITLE
refactor(load): return manifests via solve response

### DIFF
--- a/depot/load.go
+++ b/depot/load.go
@@ -1,0 +1,16 @@
+package depot
+
+// ImagesExported is the label for solve responses containing slices of
+// image manifests and configs.
+//
+// This is a base64-encoded JSON array of objects with the following fields:
+// Manifest []byte `json:"manifest"`
+// Config   []byte `json:"config"`
+const ImagesExported = "depot/images.exported"
+
+type ExportedImage struct {
+	// JSON-encoded ocispecs.Manifest.
+	Manifest []byte `json:"manifest"`
+	// JSON-encoded ocispecs.Image.
+	Config []byte `json:"config"`
+}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -59,16 +59,16 @@ type ImageWriter struct {
 	opt WriterOpt
 }
 
-func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, sessionID string, opts *ImageCommitOpts) (*ocispecs.Descriptor, error) {
+func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, sessionID string, opts *ImageCommitOpts) ([]*Committed, *ocispecs.Descriptor, error) {
 	if _, ok := inp.Metadata[exptypes.ExporterPlatformsKey]; len(inp.Refs) > 0 && !ok {
-		return nil, errors.Errorf("unable to export multiple refs, missing platforms mapping")
+		return nil, nil, errors.Errorf("unable to export multiple refs, missing platforms mapping")
 	}
 
 	isMap := len(inp.Refs) > 0
 
 	ps, err := exptypes.ParsePlatforms(inp.Metadata)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if !isMap {
@@ -91,7 +91,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	}
 	if opts.Epoch == nil {
 		if tm, ok, err := epoch.ParseSource(inp); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if ok {
 			opts.Epoch = tm
 		}
@@ -100,7 +100,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	for pk, a := range opts.Annotations {
 		if pk != "" {
 			if _, ok := inp.FindRef(pk); !ok {
-				return nil, errors.Errorf("invalid annotation: no platform %s found in source", pk)
+				return nil, nil, errors.Errorf("invalid annotation: no platform %s found in source", pk)
 			}
 		}
 		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
@@ -110,7 +110,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 	if !isMap {
 		if len(ps.Platforms) > 1 {
-			return nil, errors.Errorf("cannot export multiple platforms without multi-platform enabled")
+			return nil, nil, errors.Errorf("cannot export multiple platforms without multi-platform enabled")
 		}
 
 		var ref cache.ImmutableRef
@@ -126,7 +126,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 		remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), ref)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		var dtbi []byte
@@ -134,30 +134,30 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			if dtbi, err = buildinfo.Format(exptypes.ParseKey(inp.Metadata, exptypes.ExporterBuildInfo, p), buildinfo.FormatOpts{
 				RemoveAttrs: !opts.BuildInfoAttrs,
 			}); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
 		annotations := opts.Annotations.Platform(nil)
 		if len(annotations.Index) > 0 || len(annotations.IndexDescriptor) > 0 {
-			return nil, errors.Errorf("index annotations not supported for single platform export")
+			return nil, nil, errors.Errorf("index annotations not supported for single platform export")
 		}
 
 		config := exptypes.ParseKey(inp.Metadata, exptypes.ExporterImageConfigKey, p)
 		inlineCache := exptypes.ParseKey(inp.Metadata, exptypes.ExporterInlineCache, p)
-		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, ref, config, &remotes[0], annotations, inlineCache, dtbi, opts.Epoch, session.NewGroup(sessionID))
+		committed, err := ic.commitDistributionManifest(ctx, opts, ref, config, &remotes[0], annotations, inlineCache, dtbi, opts.Epoch, session.NewGroup(sessionID))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if mfstDesc.Annotations == nil {
-			mfstDesc.Annotations = make(map[string]string)
+		if committed.Manifest.Annotations == nil {
+			committed.Manifest.Annotations = make(map[string]string)
 		}
 		if len(ps.Platforms) == 1 {
-			mfstDesc.Platform = &ps.Platforms[0].Platform
+			committed.Manifest.Platform = &ps.Platforms[0].Platform
 		}
-		mfstDesc.Annotations[exptypes.ExporterConfigDigestKey] = configDesc.Digest.String()
+		committed.Manifest.Annotations[exptypes.ExporterConfigDigestKey] = committed.Config.Digest.String()
 
-		return mfstDesc, nil
+		return []*Committed{committed}, &committed.Manifest, nil
 	}
 
 	if len(inp.Attestations) > 0 {
@@ -169,7 +169,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	for _, p := range ps.Platforms {
 		r, ok := inp.FindRef(p.ID)
 		if !ok {
-			return nil, errors.Errorf("failed to find ref for ID %s", p.ID)
+			return nil, nil, errors.Errorf("failed to find ref for ID %s", p.ID)
 		}
 		remotesMap[p.ID] = len(refs)
 		refs = append(refs, r)
@@ -177,7 +177,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 	remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), refs...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	idx := struct {
@@ -202,12 +202,15 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 	labels := map[string]string{}
 
-	var attestationManifests []ocispecs.Descriptor
+	var (
+		attestationManifests []ocispecs.Descriptor
+		commits              []*Committed
+	)
 
 	for i, p := range ps.Platforms {
 		r, ok := inp.FindRef(p.ID)
 		if !ok {
-			return nil, errors.Errorf("failed to find ref for ID %s", p.ID)
+			return nil, nil, errors.Errorf("failed to find ref for ID %s", p.ID)
 		}
 		config := exptypes.ParseKey(inp.Metadata, exptypes.ExporterImageConfigKey, p)
 		inlineCache := exptypes.ParseKey(inp.Metadata, exptypes.ExporterInlineCache, p)
@@ -217,7 +220,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			if dtbi, err = buildinfo.Format(exptypes.ParseKey(inp.Metadata, exptypes.ExporterBuildInfo, p), buildinfo.FormatOpts{
 				RemoveAttrs: !opts.BuildInfoAttrs,
 			}); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
@@ -228,20 +231,20 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 
-		desc, _, err := ic.commitDistributionManifest(ctx, opts, r, config, remote, opts.Annotations.Platform(&p.Platform), inlineCache, dtbi, opts.Epoch, session.NewGroup(sessionID))
+		committed, err := ic.commitDistributionManifest(ctx, opts, r, config, remote, opts.Annotations.Platform(&p.Platform), inlineCache, dtbi, opts.Epoch, session.NewGroup(sessionID))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		dp := p.Platform
-		desc.Platform = &dp
-		idx.Manifests = append(idx.Manifests, *desc)
+		committed.Manifest.Platform = &dp
+		idx.Manifests = append(idx.Manifests, committed.Manifest)
 
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = desc.Digest.String()
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = committed.Manifest.Digest.String()
 
 		if attestations, ok := inp.Attestations[p.ID]; ok {
 			attestations, err := attestation.Unbundle(ctx, session.NewGroup(sessionID), attestations)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			eg, ctx2 := errgroup.WithContext(ctx)
@@ -257,7 +260,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				})
 			}
 			if err := eg.Wait(); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			var defaultSubjects []intoto.Subject
@@ -267,25 +270,27 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				}
 				pl, err := purl.RefToPURL(name, &p.Platform)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				defaultSubjects = append(defaultSubjects, intoto.Subject{
 					Name:   pl,
-					Digest: result.ToDigestMap(desc.Digest),
+					Digest: result.ToDigestMap(committed.Manifest.Digest),
 				})
 			}
 			stmts, err := attestation.MakeInTotoStatements(ctx, session.NewGroup(sessionID), attestations, defaultSubjects)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
-			desc, err := ic.commitAttestationsManifest(ctx, opts, p, desc.Digest.String(), stmts)
+			desc, err := ic.commitAttestationsManifest(ctx, opts, p, committed.Manifest.Digest.String(), stmts)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			desc.Platform = &intotoPlatform
 			attestationManifests = append(attestationManifests, *desc)
 		}
+
+		commits = append(commits, committed)
 	}
 
 	for i, mfst := range attestationManifests {
@@ -295,7 +300,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 	idxBytes, err := json.MarshalIndent(idx, "", "  ")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal index")
+		return nil, nil, errors.Wrap(err, "failed to marshal index")
 	}
 
 	idxDigest := digest.FromBytes(idxBytes)
@@ -308,15 +313,17 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	idxDone := progress.OneOff(ctx, "exporting manifest list "+idxDigest.String())
 
 	if err := content.WriteBlob(ctx, ic.opt.ContentStore, idxDigest.String(), bytes.NewReader(idxBytes), idxDesc, content.WithLabels(labels)); err != nil {
-		return nil, idxDone(errors.Wrapf(err, "error writing manifest list blob %s", idxDigest))
+		return nil, nil, idxDone(errors.Wrapf(err, "error writing manifest list blob %s", idxDigest))
 	}
 	idxDone(nil)
 
-	// DEPOT: Add image index so we can use it to pull the image in the depot client.
-	// This image index contains manifests for all platforms.
-	idxDesc.Annotations[exptypes.DepotContainerImageIndex] = string(idxBytes)
+	if opts.ExportImageVersion == ExportImageVersionV1 {
+		// DEPOT: Add image index so we can use it to pull the image in the depot client.
+		// This image index contains manifests for all platforms.
+		idxDesc.Annotations[exptypes.DepotContainerImageIndex] = string(idxBytes)
+	}
 
-	return &idxDesc, nil
+	return commits, &idxDesc, nil
 }
 
 func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefConfig, s session.Group, refs ...cache.ImmutableRef) ([]solver.Remote, error) {
@@ -356,28 +363,42 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefC
 	return out, err
 }
 
-func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, buildInfo []byte, epoch *time.Time, sg session.Group) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {
+type Committed struct {
+	// Manifest is the manifest descriptor for the committed image.
+	Manifest ocispecs.Descriptor
+	// ManifestBytes is the raw bytes of the committed image manifest.
+	// We return bytes here rather than ocispecs.Manifest as buildkit adds extra information.
+	ManifestBytes []byte
+	// Config is the config descriptor for the committed image.
+	Config ocispecs.Descriptor
+	// ConfigBytes is the raw bytes of the committed image config.
+	// We return bytes here rather than ocispecs.Image as buildkit adds extra information
+	// to support docker schema.
+	ConfigBytes []byte
+}
+
+func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, buildInfo []byte, epoch *time.Time, sg session.Group) (*Committed, error) {
 	if len(config) == 0 {
 		var err error
 		config, err = defaultImageConfig()
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	history, err := parseHistoryFromConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	remote, history, err = patchImageLayers(ctx, remote, history, ref, opts, sg)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	config, err = patchImageConfig(config, remote.Descriptors, history, inlineCache, buildInfo, epoch)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var (
@@ -438,7 +459,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 
 	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to marshal manifest")
+		return nil, errors.Wrap(err, "failed to marshal manifest")
 	}
 
 	mfstDigest := digest.FromBytes(mfstJSON)
@@ -449,7 +470,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 	mfstDone := progress.OneOff(ctx, "exporting manifest "+mfstDigest.String())
 
 	if err := content.WriteBlob(ctx, ic.opt.ContentStore, mfstDigest.String(), bytes.NewReader(mfstJSON), mfstDesc, content.WithLabels((labels))); err != nil {
-		return nil, nil, mfstDone(errors.Wrapf(err, "error writing manifest blob %s", mfstDigest))
+		return nil, mfstDone(errors.Wrapf(err, "error writing manifest blob %s", mfstDigest))
 	}
 	mfstDone(nil)
 
@@ -461,22 +482,34 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 	configDone := progress.OneOff(ctx, "exporting config "+configDigest.String())
 
 	if err := content.WriteBlob(ctx, ic.opt.ContentStore, configDigest.String(), bytes.NewReader(config), configDesc); err != nil {
-		return nil, nil, configDone(errors.Wrap(err, "error writing config blob"))
+		return nil, configDone(errors.Wrap(err, "error writing config blob"))
 	}
 	configDone(nil)
 
-	// DEPOT: Add manifest so it can be sent back to the depot client.
-	// We need this as the manifest does not appear to always
-	// be available in the content store.
-	annotations.ManifestDescriptor[exptypes.DepotContainerImageManifest] = string(mfstJSON)
-	annotations.ManifestDescriptor[exptypes.DepotContainerImageConfig] = string(config)
+	// DEPOT: backwards compatibility for older depot clients.
+	if opts.ExportImageVersion == ExportImageVersionV1 {
+		annotations.ManifestDescriptor[exptypes.DepotContainerImageManifest] = string(mfstJSON)
+		annotations.ManifestDescriptor[exptypes.DepotContainerImageConfig] = string(config)
+	}
 
-	return &ocispecs.Descriptor{
+	mfstDesc = ocispecs.Descriptor{
 		Annotations: annotations.ManifestDescriptor,
 		Digest:      mfstDigest,
 		Size:        int64(len(mfstJSON)),
 		MediaType:   manifestType,
-	}, &configDesc, nil
+	}
+
+	// DEPOT: Add manifest so it can be sent back to the depot client.
+	// We need this as the manifest does not appear to always
+	// be available in the content store.
+	committed := &Committed{
+		Manifest:      mfstDesc,
+		ManifestBytes: mfstJSON,
+		Config:        configDesc,
+		ConfigBytes:   config,
+	}
+
+	return committed, nil
 }
 
 func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *ImageCommitOpts, p exptypes.Platform, target string, statements []intoto.Statement) (*ocispecs.Descriptor, error) {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -143,7 +143,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}()
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
+	_, desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Previously, manifests and configs were sent as annotations on the image index. This caused failures when pushing to GCR and oci-mediatypes was false.

Now, a new export image option, `depot.export.image.version`, has been added.  If the version is set to `2` then we send back manifest and config in the solve response.  If not set or `1` we'll continue to send via annotations for backwards compatibility.

The response manifests and configs is a base64-encoded JSON array stored at the key `depot.export.image.version`.

https://github.com/depot/cli/pull/138