### PR TITLE
refactor: remove panic in dockerfile-frontend

### DIFF
--- a/frontend/dockerfile/cmd/dockerfile-frontend/main.go
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/main.go
@@ -27,7 +27,6 @@ func main() {
 	}
 
 	if err := grpcclient.RunFromEnvironment(appcontext.Context(), dockerfile.Build); err != nil {
-		logrus.Errorf("fatal error: %+v", err)
-		panic(err)
+		logrus.Fatalf("fatal error: %+v", err)
 	}
 }


### PR DESCRIPTION
This panic was creating log spam for expected
user failures.

Instead we log and exit 1 now.