### PR TITLE
feat: respond to gRPC health status requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Client struct {
@@ -188,6 +189,10 @@ func (c *Client) LeasesClient() leasesapi.LeasesClient {
 
 func (c *Client) LLBBridgeClient() gatewayapi.LLBBridgeClient {
 	return gatewayapi.NewLLBBridgeClient(c.conn)
+}
+
+func (c *Client) HealthClient() grpc_health_v1.HealthClient {
+	return grpc_health_v1.NewHealthClient(c.conn)
 }
 
 func (c *Client) Dialer() session.Dialer {

--- a/cmd/buildctl/health.go
+++ b/cmd/buildctl/health.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+
+	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var healthCommand = cli.Command{
+	Name:   "health",
+	Usage:  "Checks the buildkitd gRPC health",
+	Action: health,
+}
+
+func health(clicontext *cli.Context) error {
+	client, err := bccommon.ResolveClient(clicontext)
+	if err != nil {
+		return err
+	}
+
+	healthClient := client.HealthClient()
+	resp, err := healthClient.Check(bccommon.CommandContext(clicontext), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(resp.Status.String())
+
+	return nil
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -94,6 +94,7 @@ func main() {
 		buildCommand,
 		debugCommand,
 		dialStdioCommand,
+		healthCommand,
 	}
 
 	var debugEnabled bool

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -68,6 +68,8 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func init() {
@@ -244,6 +246,7 @@ func main() {
 		opts = append(opts, grpc.KeepaliveParams(depot.LoadKeepaliveServerParams()))
 
 		server := grpc.NewServer(opts...)
+		grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 
 		// relative path does not work with nightlyone/lockfile
 		root, err := filepath.Abs(cfg.Root)


### PR DESCRIPTION
Currently, it is awkward to check if buildkitd is alive. This adds the standard gRPC health check; it always responds that buildkitd is healthy.