### PR TITLE
fix: always fsync bolt for safety

### DIFF
--- a/solver/bboltcachestorage/storage.go
+++ b/solver/bboltcachestorage/storage.go
@@ -37,7 +37,6 @@ func NewStore(dbPath string) (*Store, error) {
 	}); err != nil {
 		return nil, err
 	}
-	db.NoSync = true
 	return &Store{db: db}, nil
 }
 


### PR DESCRIPTION
Bolt seemingly gets corrupted every so often.

Buildkit explicitly turns off fsync; I suspect this was accidentally committed to the repo.

Turning fsync back on (the default setting) should give us extra safety around buildkit shutdowns.