### PR TITLE
fix: close bolt metadata on shutdown

### DIFF
--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -209,6 +209,10 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 
 func (w *Worker) Close() error {
 	var rerr error
+	if err := w.MetadataStore.Close(); err != nil {
+		rerr = multierror.Append(rerr, err)
+	}
+
 	for _, provider := range w.NetworkProviders {
 		if err := provider.Close(); err != nil {
 			rerr = multierror.Append(rerr, err)


### PR DESCRIPTION
We have seen bolt corruption every so often.
The metadata boltdb was never closed and could
potentially lead to corruption.