### PR TITLE
Make gRPC server terminate TLS

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -68,6 +68,7 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -245,6 +246,12 @@ func main() {
 		opts = append(opts, grpc.KeepaliveEnforcementPolicy(depot.LoadKeepaliveEnforcementPolicy()))
 		opts = append(opts, grpc.KeepaliveParams(depot.LoadKeepaliveServerParams()))
 
+		// DEPOT: if TLS is configured, make the gRPC server terminate and validate those credentials
+		// so that we get AuthInfo in the gRPC handlers
+		if tlsConfig, err := serverCredentials(cfg.GRPC.TLS); err == nil {
+			opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		}
+
 		server := grpc.NewServer(opts...)
 		grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 
@@ -341,14 +348,17 @@ func serveGRPC(cfg config.GRPCConfig, server *grpc.Server, errCh chan error) err
 	if len(addrs) == 0 {
 		return errors.New("--addr cannot be empty")
 	}
-	tlsConfig, err := serverCredentials(cfg.TLS)
-	if err != nil {
-		return err
-	}
+
+	// DEPOT: skip listener TLS as we make the gRPC server validate TLS instead
+	// tlsConfig, err := serverCredentials(cfg.TLS)
+	// if err != nil {
+	// 	return err
+	// }
+
 	eg, _ := errgroup.WithContext(context.Background())
 	listeners := make([]net.Listener, 0, len(addrs))
 	for _, addr := range addrs {
-		l, err := getListener(addr, *cfg.UID, *cfg.GID, tlsConfig)
+		l, err := getListener(addr, *cfg.UID, *cfg.GID, nil)
 		if err != nil {
 			for _, l := range listeners {
 				l.Close()
@@ -555,7 +565,9 @@ func getListener(addr string, uid, gid int, tlsConfig *tls.Config) (net.Listener
 		}
 
 		if tlsConfig == nil {
-			logrus.Warnf("TLS is not enabled for %s. enabling mutual TLS authentication is highly recommended", addr)
+			// DEPOT: don't print this warning because we give the gRPC the TLS info directly, rather
+			// than terminating TLS at the listener
+			// logrus.Warnf("TLS is not enabled for %s. enabling mutual TLS authentication is highly recommended", addr)
 			return l, nil
 		}
 		return tls.NewListener(l, tlsConfig), nil

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -248,7 +248,7 @@ func main() {
 
 		// DEPOT: if TLS is configured, make the gRPC server terminate and validate those credentials
 		// so that we get AuthInfo in the gRPC handlers
-		if tlsConfig, err := serverCredentials(cfg.GRPC.TLS); err == nil {
+		if tlsConfig, err := serverCredentials(cfg.GRPC.TLS); err == nil && tlsConfig != nil {
 			opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 		}
 
@@ -354,11 +354,12 @@ func serveGRPC(cfg config.GRPCConfig, server *grpc.Server, errCh chan error) err
 	// if err != nil {
 	// 	return err
 	// }
+	var tlsConfig *tls.Config
 
 	eg, _ := errgroup.WithContext(context.Background())
 	listeners := make([]net.Listener, 0, len(addrs))
 	for _, addr := range addrs {
-		l, err := getListener(addr, *cfg.UID, *cfg.GID, nil)
+		l, err := getListener(addr, *cfg.UID, *cfg.GID, tlsConfig)
 		if err != nil {
 			for _, l := range listeners {
 				l.Close()


### PR DESCRIPTION
Currently when TLS config is specified, BuildKit gives this config to a `tls.Listener` rather than to the gRPC server. This allows it to disable TLS for the unix socket, in the case where there are both `tcp` and `unix` listeners, but this means that the gRPC server doesn't actually have access to the client `AuthInfo` since TLS is being terminated above it.

This PR gives the TLS info to the gRPC server as credentials, so that it's able to provide `AuthInfo` to the method handlers.