### PR TITLE
fix: use sha256 for merge/diff op cache maps

### DIFF
--- a/solver/llbsolver/ops/diff.go
+++ b/solver/llbsolver/ops/diff.go
@@ -56,7 +56,7 @@ func (d *diffOp) CacheMap(ctx context.Context, group session.Group, index int) (
 	}
 
 	cm := &solver.CacheMap{
-		Digest: digest.Digest(dt),
+		Digest: digest.FromBytes(dt),
 		Deps: make([]struct {
 			Selector          digest.Digest
 			ComputeDigestFunc solver.ResultBasedCacheFunc

--- a/solver/llbsolver/ops/merge.go
+++ b/solver/llbsolver/ops/merge.go
@@ -48,7 +48,7 @@ func (m *mergeOp) CacheMap(ctx context.Context, group session.Group, index int) 
 	}
 
 	cm := &solver.CacheMap{
-		Digest: digest.Digest(dt),
+		Digest: digest.FromBytes(dt),
 		Deps: make([]struct {
 			Selector          digest.Digest
 			ComputeDigestFunc solver.ResultBasedCacheFunc


### PR DESCRIPTION
The digest of the merge/diff ops' CacheMap
would be json strings like:

```
{"Type":"buildkit.merge.v0","Merge":{"inputs":[{"input":0},{"input":1}]}}
```

rather than a sha256.