### PR TITLE
perf: switch num concurrent layer fetch/push to 32

### DIFF
--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -20,7 +20,7 @@ type contextKeyT string
 
 var contextKey = contextKeyT("buildkit/util/resolver/limited")
 
-var Default = New(12)
+var Default = New(32)
 
 type Group struct {
 	mu   sync.Mutex

--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -3,7 +3,9 @@ package limited
 import (
 	"context"
 	"io"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -20,7 +22,18 @@ type contextKeyT string
 
 var contextKey = contextKeyT("buildkit/util/resolver/limited")
 
-var Default = New(32)
+var Default = New(12)
+
+func init() {
+	if os.Getenv("DEPOT_RESOLVER_CONCURRENCY") != "" {
+		i, err := strconv.Atoi(os.Getenv("DEPOT_RESOLVER_CONCURRENCY"))
+		if err != nil {
+			panic(err)
+		}
+
+		Default = New(i)
+	}
+}
 
 type Group struct {
 	mu   sync.Mutex


### PR DESCRIPTION
We are seeing slow container push and are wondering if the global pool of concurrent layer pushes is causing a slowdown.

This PR addresses both concurrent fetch and pulls as the same global variable controls the semaphore weight.

Additionally, this adds printing of each layer as it is pushed to a remote registry.

( PR #8 previously had increased this from 4 to 12 )